### PR TITLE
Integrating with Toggl API V9

### DIFF
--- a/org-toggl.el
+++ b/org-toggl.el
@@ -83,11 +83,11 @@ Add the auth token)."
 	   :sync sync
 	   :timeout (or timeout toggl-default-timeout)))
 
-(defun toggl-request-put (request data &optional sync success-fun error-fun timeout)
-  "Send a GET REQUEST to toggl.com, with TIMEOUT.
+(defun toggl-request-patch (request data &optional sync success-fun error-fun timeout)
+  "Send PATCH REQUEST to toggl.com, with TIMEOUT.
 Add the auth token)."
   (request (toggl-create-api-url request)
-	   :type "PUT"
+	   :type "PATCH"
 	   :data data
 	   :parser #'json-read
 	   :headers (list (toggl-prepare-auth-header)
@@ -199,9 +199,9 @@ It is assumed that no two projects have the same name."
   "Stop running Toggl time entry."
   (interactive "p")
   (when toggl-current-time-entry
-    (toggl-request-put
-     (format "time_entries/%s/stop"
-	     (alist-get 'id (alist-get 'data toggl-current-time-entry)))
+    (toggl-request-patch
+     (format "/time_entries/%s/stop"
+	     (alist-get 'id toggl-current-time-entry))
      nil
      nil
      (cl-function
@@ -219,7 +219,7 @@ By default, delete the current one."
   (when toggl-current-time-entry
     (setq tid (or tid (alist-get 'id (alist-get 'data toggl-current-time-entry))))
     (toggl-request-delete
-     (format "time_entries/%s" tid)
+     (format "/time_entries/%s" tid)
      nil
      (cl-function
       (lambda (&key data &allow-other-keys)

--- a/org-toggl.el
+++ b/org-toggl.el
@@ -247,6 +247,13 @@ By default, delete the current one."
   :type 'boolean
   :group 'toggl)
 
+;(defun org-toggl-clock ()
+;  "Start a Toggl time entry based on current heading."
+;  (interactive)
+;  (let* ((heading (substring-no-properties (org-get-heading t t t t)))
+;	 (project (org-entry-get (point) "toggl-project" org-toggl-inherit-toggl-properties))
+;	 (pid (toggl-get-pid project)))
+;    (when pid (toggl-start-time-entry heading pid t))))
 
 (defun org-toggl-clock-in ()
   "Start a Toggl time entry based on current heading."

--- a/org-toggl.el
+++ b/org-toggl.el
@@ -70,7 +70,7 @@ Add the auth token)."
 	   :timeout (or timeout toggl-default-timeout)))
 
 (defun toggl-request-post (request data &optional sync success-fun error-fun timeout)
-  "Send a GET REQUEST to toggl.com, with TIMEOUT.
+  "Send a POST REQUEST to toggl.com, with TIMEOUT.
 Add the auth token)."
   (request (toggl-create-api-url request)
 	   :type "POST"

--- a/org-toggl.el
+++ b/org-toggl.el
@@ -36,17 +36,22 @@
   :type 'string
   :group 'toggl)
 
+(defcustom toggl-workspace-id ""
+  "Toggl workspace id to work with"
+  :type 'string
+  :group 'toggl)
+
 (defcustom toggl-default-timeout 20
   "Default timeout for HTTP requests."
   :type 'integer
   :group 'toggl)
 
-(defvar toggl-api-url "https://api.track.toggl.com/api/v8/"
+(defvar toggl-api-url "https://api.track.toggl.com/api/v9/workspaces/"
   "The URL for making API calls.")
 
 (defun toggl-create-api-url (string)
   "Prepend Toogl API URL to STRING."
-  (concat toggl-api-url string))
+  (concat toggl-api-url toggl-workspace-id string))
 
 (defun toggl-prepare-auth-header ()
   "Return a cons to be put into headers for authentication."
@@ -116,15 +121,16 @@ its id.")
   "Fill in `toggl-projects' (asynchronously)."
   (interactive)
   (toggl-request-get
-   "me?with_related_data=true"
+   "/projects"
    nil
    (cl-function
     (lambda (&key data &allow-other-keys)
       (setq toggl-projects
-	    (mapcar (lambda (project)
-		      (cons (substring-no-properties (alist-get 'name project))
-			    (alist-get 'id project)))
-		    (alist-get 'projects (alist-get 'data data))))
+            (mapcar (lambda (project)
+                      (cons (substring-no-properties (alist-get 'name project)) (alist-get 'id project)))
+                    data
+                    )
+            )
       (message "Toggl projects successfully downloaded.")))
    (cl-function
     (lambda (&key error-thrown &allow-other-keys)

--- a/org-toggl.el
+++ b/org-toggl.el
@@ -102,7 +102,7 @@ Add the auth token)."
 Add the auth token)."
   (request (toggl-create-api-url request)
 	   :type "DELETE"
-	   :parser #'json-read
+	   :parser 'buffer-string
 	   :headers (list (toggl-prepare-auth-header))
 	   :success success-fun
 	   :error error-fun
@@ -217,15 +217,15 @@ It is assumed that no two projects have the same name."
 By default, delete the current one."
   (interactive "ip")
   (when toggl-current-time-entry
-    (setq tid (or tid (alist-get 'id (alist-get 'data toggl-current-time-entry))))
     (toggl-request-delete
-     (format "/time_entries/%s" tid)
+     (format "/time_entries/%s" (alist-get 'id toggl-current-time-entry))
      nil
      (cl-function
-      (lambda (&key data &allow-other-keys)
-	(when (= tid (alist-get 'id (alist-get 'data toggl-current-time-entry)))
-	  (setq toggl-current-time-entry nil))
-	(when show-message (message "Toggl time entry deleted."))))
+      (lambda (&key response &allow-other-keys)
+        (when (= (request-response-status-code response) 200)
+          (setq toggl-current-time-entry nil))
+		      (when show-message (message "Toggl time entry deleted.")))
+      )
      (cl-function
       (lambda (&key error-thrown &allow-other-keys)
 	(when show-message (message "Deleting time entry failed because %s" error-thrown)))))))

--- a/org-toggl.el
+++ b/org-toggl.el
@@ -38,7 +38,7 @@
 
 (defcustom toggl-workspace-id ""
   "Toggl workspace id to work with"
-  :type 'string
+  :type 'integer
   :group 'toggl)
 
 (defcustom toggl-default-timeout 20


### PR DESCRIPTION
This version integrates with org-mode with toggl api version 9 

- It is not necessary to have one default project, if the project is not defined in the task, you can selected interactively and the use it again after. 
- It is necessary to define a workspace Id in order to have all the data for the requests